### PR TITLE
Reset gitHistory to false when creating inner graph.

### DIFF
--- a/codeviz_backend/src/main/java/codeViz/CodeVizController.java
+++ b/codeviz_backend/src/main/java/codeViz/CodeVizController.java
@@ -178,6 +178,7 @@ public class CodeVizController {
         if (currentLevel.getChild() != null){
             EntityType newLevel = currentLevel.getChild();
             System.out.println("Generate inner graph for " + nodeName + " at " + currentLevel);
+            gitHistory = false; // default git history is false
             codeVizInterface.generateInnerGraph(nodeName, currentLevel, newLevel, GEXF_FILE, gitHistory);
             currentLevel = newLevel;
         }


### PR DESCRIPTION
Problem: When viewing the git history graph, and then clicking on a class, the method view shows the "Git History" button pressed (which should be disabled for method view).

Fix: set `gitHistory` to false before creating any inner graph.


With the bug:
![image](https://github.com/maishabd23/CodeViz/assets/59773247/64f3c5bb-d90f-4395-b2fa-fc570879cfe8)


With the fix:
![image](https://github.com/maishabd23/CodeViz/assets/59773247/110348a2-d2e1-4206-8648-5f8a6c3052b0)
