### PR TITLE
Fix up percentages so that scrollbar doesn't always appear, and fix node details position.

### DIFF
--- a/codeviz_frontend/src/App.css
+++ b/codeviz_frontend/src/App.css
@@ -14,6 +14,9 @@ nav {
   padding: 10px 10px;
   background-color: slategray;
   margin: 0;
+  min-height: 40px;
+  max-height: 100px;
+  height: 10%;
 }
 
 .nav--main {
@@ -118,12 +121,13 @@ canvas {
 #nodeDetailsDisplay {
   resize: both;
   position: absolute;
-  top: 55%;
+  /* top + height = 100% */
+  top: 75%;
   text-align: left;
   padding: 20px; 
   background-color: rgba(255,255,255,0.9);
   width: calc(100% - 1em);
-  height: 200px;
+  height: 25%;
   overflow: auto; 
   box-sizing: border-box;
   border-radius: 10px;
@@ -208,7 +212,7 @@ canvas {
 
 .main {
   display: flex;
-  height: 100%;
+  height: 84%; /* 20% menu + 84% < 100% (need a buffer, that way scrollbar appear all the time) */
 }
 
 .center {


### PR DESCRIPTION
Examples of the screen layouts:
![image](https://github.com/maishabd23/CodeViz/assets/59773247/cd55e177-d9d8-45af-85a3-1aabd88c5015)

![image](https://github.com/maishabd23/CodeViz/assets/59773247/8bee4d23-0316-4459-b8b4-7f7f4f8cd95a)


On my laptop screen:
![image](https://github.com/maishabd23/CodeViz/assets/59773247/60fc3d84-dde5-4ca2-b2af-1d2b1dc3e614)
